### PR TITLE
replace c style cast to c++ style cast

### DIFF
--- a/nac_client/src/core/DirectoryMonitor.cpp
+++ b/nac_client/src/core/DirectoryMonitor.cpp
@@ -68,7 +68,7 @@ void DirectoryMonitor::MonitoringThreadFunc(DirectoryMonitor *self) {
 
         length = read(self->_fdMonitor, inotifyBuffer, INOTIFY_BUFFER);
         while (index < length) {
-            struct inotify_event *event = (struct inotify_event*)&inotifyBuffer[index];
+            struct inotify_event *event = reinterpret_cast<inotify_event *>(&inotifyBuffer[index]);
             if (event->mask & IN_IGNORED) {
                 //  inotify_rm_watch가 호출됨
                 break;


### PR DESCRIPTION
Should avoid C style type casts, since they aren't checked on compilation time, thus can fail at runtime. 

Replaced C style type cast to appropriate cast (in this case, `reinterpret_cast`)